### PR TITLE
- Discover the root device

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -4,5 +4,5 @@ use ExtUtils::MakeMaker;
 WriteMakefile(
     EXE_FILES => ['usr/sbin/azuremetadata'],
     NAME      => 'AzureMetadata',
-    VERSION   => '4.0.1'
+    VERSION   => '4.0.2'
 );

--- a/azuremetadata.spec
+++ b/azuremetadata.spec
@@ -2,7 +2,7 @@
 # spec file for package azureMetaData
 # this code base is under development
 #
-# Copyright (c) 2015 SUSE LLC
+# Copyright (c) 2020 SUSE LLC
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed
@@ -20,7 +20,7 @@ Name:           azuremetadata
 # For compatibility, remove provides 11/11/2015
 Provides:       azureMetaData
 Obsoletes:      azureMetaData <= 2.0.1
-Version:        4.0.1
+Version:        4.0.2
 Release:        0
 License:        GPL-3.0+
 Summary:        Collect instance metadata in Azure

--- a/usr/sbin/azuremetadata
+++ b/usr/sbin/azuremetadata
@@ -111,9 +111,6 @@ sub parse_options {
         print STDERR "Please provide a query option.";
         exit 1;
     }
-    if (! $options{device}) {
-        $options{device} = '/dev/sda';
-    }
     $options{output} = 'json';
     if ($options{xmlOut}) {
         $options{output} = 'xml';
@@ -143,8 +140,8 @@ sub usage {
     print "\n";
     print "  options\n";
     print "    [ --device | -d <image file or disk device> ]\n";
-    print "      Specify device for tag discovery. Default device\n";
-    print "      is set to '/dev/sda'\n";
+    print "      Specify device for tag discovery. If not specified\n";
+    print "      the device will be discovered.'\n";
     print "    [ --xml | -x ]\n";
     print "      Wrap information in XML markup\n";
     print "    [ --bare | -b ]\n";


### PR DESCRIPTION
  + With asynchronous device detection we can no longer assume that
    the root is on /dev/sda, the previous default device.