### PR TITLE
Fix XML output

### DIFF
--- a/azuremetadata
+++ b/azuremetadata
@@ -58,8 +58,7 @@ try:
             util.print_pretty(print_xml=args.xml, print_json=args.json, file=fh)
         else:
             result = util.query(ordered_args)
-            for item in result:
-                util.print_pretty(print_xml=args.xml, print_json=args.json, data=item, file=fh)
+            util.print_pretty(print_xml=args.xml, print_json=args.json, data=result, file=fh)
     finally:
         if fh:
             fh.close()

--- a/lib/azuremetadata/azuremetadatautils.py
+++ b/lib/azuremetadata/azuremetadatautils.py
@@ -115,7 +115,8 @@ class AzureMetadataUtils:
     def query(self, args):
         """Generates output based on command line arguments."""
         root = self._available_params
-        result = []
+        result = {}
+        parents = []
 
         while len(args) > 0:
             arg, argval = args.pop(0)
@@ -136,18 +137,26 @@ class AzureMetadataUtils:
 
             if isinstance(value, list):
                 root = value[argval]
+                parents.append(arg)
                 continue
 
             if isinstance(value, dict):
                 root = value
+                parents.append(arg)
                 continue
 
             if value is None:
                 raise QueryException("Nothing found for '{}'".format(arg))
             else:
-                result.append({arg: value})
+                target = result
+                for item in parents:
+                    target[item] = {}
+                    target = target[item]
+
+                target[arg] = value
 
             root = self._available_params
+            parents = []
 
         if root != self._available_params:
             raise QueryException("Unfinished query")

--- a/python3-azuremetadata.spec
+++ b/python3-azuremetadata.spec
@@ -18,7 +18,7 @@
 
 %define upstream_name azuremetadata
 Name:           python3-azuremetadata
-Version:        5.0.1
+Version:        5.1.0
 # Packaged renamed in SLE15
 Provides:       azuremetadata
 Obsoletes:      azuremetadata < 5.0.0

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -142,7 +142,7 @@ def test_query_unique():
 
     result = util.query(args)
 
-    assert result == [{'test': 4}]
+    assert result == {'test': 4}
 
 
 def test_query_root_parent():
@@ -151,7 +151,7 @@ def test_query_root_parent():
 
     result = util.query(args)
 
-    assert result == [{'bar': 1}]
+    assert result == {'foo': {'bar': 1}}
 
 
 def test_query_list_index():
@@ -160,7 +160,7 @@ def test_query_list_index():
 
     result = util.query(args)
 
-    assert result == [{'foo': 3}]
+    assert result == {'baz': { 'bar': {'foo': 3}}}
 
 
 def test_available_params():


### PR DESCRIPTION
Currently filtered output is handled as a list of tuples, due to the fact there might be JSON keys with the same name in different sections of the output:

```
$ azuremetadata -a 2019-08-15 --compute --name --plan --name --osDisk --name 
name: ivan-test
name: 
name: ivan-test_OsDisk_1_fc700f778d1d49cf8a2e0fb7a7430e4e
```

That doesn't produce good XML or JSON output, however:

```
$ azuremetadata -a 2019-08-15 --compute --name --plan --name --osDisk --name --json
{"name": "ivan-test"}
{"name": ""}
{"name": "ivan-test_OsDisk_1_fc700f778d1d49cf8a2e0fb7a7430e4e"}
```

With this change, the resulting document will be a hash of hashes after the filters are applied:

```
$ azuremetadata -a 2019-08-15 --compute --name --plan --name --osDisk --name --json
compute:
    name: ivan-test
plan:
    name: 
osDisk:
    name: ivan-test_OsDisk_1_fc700f778d1d49cf8a2e0fb7a7430e4e
```

And JSON output will look like so:

```
$ azuremetadata -a 2019-08-15 --compute --name --plan --name --osDisk --name --json
{"compute": {"name": "ivan-test"}, "plan": {"name": ""}, "osDisk": {"name": "ivan-test_OsDisk_1_fc700f778d1d49cf8a2e0fb7a7430e4e"}}
```
